### PR TITLE
Force replacement on name changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.7.3 (12 26, 2025)
+
+- Force resource replacement if the name attribute changes
+
 ## v0.7.2 (07 23, 2025)
 
 - Add import documentation.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ build:
 	@go build -v -o $(PLUGIN_BINARY_NAME)
 
 test:
-	go test -race -v github.com/granular-oss/terraform-provider-credstash/credstash
+	go test -race -v \
+		github.com/granular-oss/terraform-provider-credstash \
+		github.com/granular-oss/terraform-provider-credstash/credstash
 
 install: uninstall build
 	@echo "Installing TF Plugin locally"

--- a/resource_secrets.go
+++ b/resource_secrets.go
@@ -22,6 +22,7 @@ func resourceSecret() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "name of the secret",
 			},
 			"table": {

--- a/resource_secrets_test.go
+++ b/resource_secrets_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceSecretNameFieldForceNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		oldName string
+		newName string
+		expect  bool
+	}{
+		{
+			name:    "name change should require replacement",
+			oldName: "secret-1",
+			newName: "secret-2",
+			expect:  true,
+		},
+		{
+			name:    "same name should not require replacement",
+			oldName: "secret-1",
+			newName: "secret-1",
+			expect:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := resourceSecret()
+			nameField := resource.Schema["name"]
+			
+			// Verify ForceNew is set
+			assert.True(t, nameField.ForceNew, "name field should have ForceNew=true")
+		})
+	}
+}


### PR DESCRIPTION
When the `name` of a secret changes, in-place replacement of the resource fails. This change forces a replacement of the resource instead of in-place updates when the `name` attribute changes.