### PR TITLE
Add `ForceNew` to credstash_secret name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.0 (03 16, 2026)
+
+- Add `ForceNew` to `credstash_secret` `name` attribute so that changing the name forces resource replacement instead of being silently ignored.
+
 ## v0.7.2 (07 23, 2025)
 
 - Add import documentation.

--- a/resource_secrets.go
+++ b/resource_secrets.go
@@ -22,6 +22,7 @@ func resourceSecret() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "name of the secret",
 			},
 			"table": {


### PR DESCRIPTION
Changing the name of a `credstash_secret` was silently ignored because the update function only handled changes to value, generate, and version. Since secrets are keyed by name in DynamoDB, a name change is semantically a new secret and should force replacement.

Should fix https://github.com/granular-oss/terraform-provider-credstash/pull/23.